### PR TITLE
Feature/uiview cells

### DIFF
--- a/Mew.xcodeproj/project.pbxproj
+++ b/Mew.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		29350EB622BF04C0003A86B4 /* TableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29350EB222BF04BF003A86B4 /* TableViewCell.swift */; };
 		29350EB722BF04C0003A86B4 /* TableViewHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29350EB322BF04C0003A86B4 /* TableViewHeaderFooterView.swift */; };
 		29350EB822BF04C0003A86B4 /* CollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29350EB422BF04C0003A86B4 /* CollectionReusableView.swift */; };
+		296A6AA623169CA2008733C6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296A6AA523169CA2008733C6 /* ViewController.swift */; };
+		296A6AAA2316A6B5008733C6 /* TableViewCell+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296A6AA92316A6B5008733C6 /* TableViewCell+UIKit.swift */; };
+		296A6AAE2316A957008733C6 /* TableViewHeaderFooterView+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296A6AAD2316A957008733C6 /* TableViewHeaderFooterView+UIKit.swift */; };
+		296A6AB12316AA1A008733C6 /* CollectionReusableView+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296A6AB02316AA1A008733C6 /* CollectionReusableView+UIKit.swift */; };
+		296A6AB32316ACF1008733C6 /* CollectionViewCell+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296A6AB22316ACF1008733C6 /* CollectionViewCell+UIKit.swift */; };
 		29D7467922C2F85900C9FCF4 /* EnvironmentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D7467822C2F85900C9FCF4 /* EnvironmentRequest.swift */; };
 		29D7468722C2FC2700C9FCF4 /* ViewControllerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D7468622C2FC2700C9FCF4 /* ViewControllerRequest.swift */; };
 		29D7468922C2FC3000C9FCF4 /* ViewControllerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D7468822C2FC3000C9FCF4 /* ViewControllerResponse.swift */; };
@@ -67,6 +72,11 @@
 		29350EB222BF04BF003A86B4 /* TableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCell.swift; sourceTree = "<group>"; };
 		29350EB322BF04C0003A86B4 /* TableViewHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderFooterView.swift; sourceTree = "<group>"; };
 		29350EB422BF04C0003A86B4 /* CollectionReusableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionReusableView.swift; sourceTree = "<group>"; };
+		296A6AA523169CA2008733C6 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		296A6AA92316A6B5008733C6 /* TableViewCell+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableViewCell+UIKit.swift"; sourceTree = "<group>"; };
+		296A6AAD2316A957008733C6 /* TableViewHeaderFooterView+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TableViewHeaderFooterView+UIKit.swift"; sourceTree = "<group>"; };
+		296A6AB02316AA1A008733C6 /* CollectionReusableView+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionReusableView+UIKit.swift"; sourceTree = "<group>"; };
+		296A6AB22316ACF1008733C6 /* CollectionViewCell+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionViewCell+UIKit.swift"; sourceTree = "<group>"; };
 		29D7467822C2F85900C9FCF4 /* EnvironmentRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentRequest.swift; sourceTree = "<group>"; };
 		29D7468622C2FC2700C9FCF4 /* ViewControllerRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerRequest.swift; sourceTree = "<group>"; };
 		29D7468822C2FC3000C9FCF4 /* ViewControllerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerResponse.swift; sourceTree = "<group>"; };
@@ -115,6 +125,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		296A6AAF2316A993008733C6 /* Cells+UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				296A6AA523169CA2008733C6 /* ViewController.swift */,
+				296A6AB22316ACF1008733C6 /* CollectionViewCell+UIKit.swift */,
+				296A6AB02316AA1A008733C6 /* CollectionReusableView+UIKit.swift */,
+				296A6AA92316A6B5008733C6 /* TableViewCell+UIKit.swift */,
+				296A6AAD2316A957008733C6 /* TableViewHeaderFooterView+UIKit.swift */,
+			);
+			path = "Cells+UIKit";
+			sourceTree = "<group>";
+		};
 		29D7467722C2F7B700C9FCF4 /* Environment */ = {
 			isa = PBXGroup;
 			children = (
@@ -128,8 +150,8 @@
 		D2568DD7214BC00A00FCA44A /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				29350EB422BF04C0003A86B4 /* CollectionReusableView.swift */,
 				29350EB122BF04BF003A86B4 /* CollectionViewCell.swift */,
+				29350EB422BF04C0003A86B4 /* CollectionReusableView.swift */,
 				29350EB222BF04BF003A86B4 /* TableViewCell.swift */,
 				29350EB322BF04C0003A86B4 /* TableViewHeaderFooterView.swift */,
 			);
@@ -245,6 +267,7 @@
 				D279A3042136B31A007B045A /* Protocols */,
 				D279A3052136B31F007B045A /* ContainerView */,
 				D2568DD7214BC00A00FCA44A /* Cells */,
+				296A6AAF2316A993008733C6 /* Cells+UIKit */,
 			);
 			name = Mew;
 			path = Sources/Mew;
@@ -386,6 +409,7 @@
 			buildActionMask = 0;
 			files = (
 				29350EAB22BF0491003A86B4 /* CellProtocol.swift in Sources */,
+				296A6AB32316ACF1008733C6 /* CollectionViewCell+UIKit.swift in Sources */,
 				29D7468922C2FC3000C9FCF4 /* ViewControllerResponse.swift in Sources */,
 				D25C01C821620C0100935A18 /* BackwardCompatibility.swift in Sources */,
 				29350EB522BF04C0003A86B4 /* CollectionViewCell.swift in Sources */,
@@ -395,10 +419,14 @@
 				29350EB622BF04C0003A86B4 /* TableViewCell.swift in Sources */,
 				29350EA922BF0491003A86B4 /* Emittable.swift in Sources */,
 				29D7467922C2F85900C9FCF4 /* EnvironmentRequest.swift in Sources */,
+				296A6AB12316AA1A008733C6 /* CollectionReusableView+UIKit.swift in Sources */,
 				29350EB722BF04C0003A86B4 /* TableViewHeaderFooterView.swift in Sources */,
 				29350EB022BF04AB003A86B4 /* ContainerView.swift in Sources */,
+				296A6AA623169CA2008733C6 /* ViewController.swift in Sources */,
+				296A6AAE2316A957008733C6 /* TableViewHeaderFooterView+UIKit.swift in Sources */,
 				29350EB822BF04C0003A86B4 /* CollectionReusableView.swift in Sources */,
 				29350EA722BF0491003A86B4 /* Injectable.swift in Sources */,
+				296A6AAA2316A6B5008733C6 /* TableViewCell+UIKit.swift in Sources */,
 				29350EAF22BF04AB003A86B4 /* Container.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
@@ -13,7 +13,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     /// Register dequeueable header/footer class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func registerHeaderFooterView(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
+    static func registerAsCollectionViewHeaderFooterView(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
         CollectionReusableView<Self>.register(to: collectionView, for: kind)
     }
     
@@ -53,8 +53,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     /// Register dequeueable header/footer class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func registerHeaderFooterView(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
-        ViewController<Self>.registerHeaderFooterView(on: collectionView, for: kind)
+    static func registerAsCollectionViewHeaderFooterView(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
+        ViewController<Self>.registerAsCollectionViewHeaderFooterView(on: collectionView, for: kind)
     }
     
     /// Dequeue Injectable header/footer instance from collectionView

--- a/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
@@ -10,14 +10,14 @@ import UIKit
 
 // MARK: - CollectionReusableView with UIViewController
 public extension Instantiatable where Self: UIViewController, Self: Injectable {
-    /// Register dequeueable cell class for collectionView
+    /// Register dequeueable header/footer class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
     static func register(to collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
         CollectionReusableView<Self>.register(to: collectionView, for: kind)
     }
     
-    /// Dequeue Injectable cell instance from collectionView
+    /// Dequeue Injectable header/footer instance from collectionView
     ///
     /// - Parameters:
     ///   - collectionView: Parent collectionView that must have registered cell.
@@ -25,14 +25,14 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     ///   - input: The ViewController's input.
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
-    /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    /// - Returns: The header/footer instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
     static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionReusableView<Self>.dequeued(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
 public extension Instantiatable where Self: UIViewController, Self: Injectable, Self: Emittable {
-    /// Dequeue Injectable/Emittable cell instance from collectionView
+    /// Dequeue Injectable/Emittable header/footer instance from collectionView
     ///
     /// - Parameters:
     ///   - collectionView: Parent collectionView that must have registered cell.
@@ -50,14 +50,14 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 
 // MARK: - CollectionReusableView with UIView
 public extension Instantiatable where Self: UIView, Self: Injectable {
-    /// Register dequeueable cell class for collectionView
+    /// Register dequeueable header/footer class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
     static func register(to collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
         ViewController<Self>.register(to: collectionView, for: kind)
     }
     
-    /// Dequeue Injectable cell instance from collectionView
+    /// Dequeue Injectable header/footer instance from collectionView
     ///
     /// - Parameters:
     ///   - collectionView: Parent collectionView that must have registered cell.
@@ -65,14 +65,14 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - input: The View's input.
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
-    /// - Returns: The Cell instance that added the View.
+    /// - Returns: The header/footer instance that added the View.
     static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return ViewController<Self>.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
 public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
-    /// Dequeue Injectable/Emittable cell instance from collectionView
+    /// Dequeue Injectable/Emittable header/footer instance from collectionView
     ///
     /// - Parameters:
     ///   - collectionView: Parent collectionView that must have registered cell.

--- a/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
@@ -49,12 +49,12 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 
 
 // MARK: - CollectionReusableView with UIView
-public extension Instantiatable where Self: UIView, Self: Injectable {
+public extension Injectable where Self: UIView {
     /// Register dequeueable header/footer class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func registerAsCollectionViewHeaderFooterView(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
-        ViewController<Self>.registerAsCollectionViewHeaderFooterView(on: collectionView, for: kind)
+    static func registerAsCollectionViewHeaderFooterView<Parent: UIViewController>(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind, parent: Parent.Type) where Parent: Instantiatable {
+        ViewController<Self, Parent>.registerAsCollectionViewHeaderFooterView(on: collectionView, for: kind)
     }
     
     /// Dequeue Injectable header/footer instance from collectionView
@@ -66,12 +66,12 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the View.
-    static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueAsCollectionViewHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable {
+        return ViewController<Self, V>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
-public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
+public extension Injectable where Self: UIView, Self: Emittable {
     /// Dequeue Injectable/Emittable header/footer instance from collectionView
     ///
     /// - Parameters:
@@ -82,8 +82,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the View.
-    static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueAsCollectionViewHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable {
+        return ViewController<Self, V>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 

--- a/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
@@ -1,0 +1,89 @@
+//
+//  CollectionReusableView+UIKit.swift
+//  Mew
+//
+//  Created by Shun Usami on 2019/08/28.
+//  Copyright © 2019 Mercari. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - CollectionReusableView with UIViewController
+public extension Instantiatable where Self: UIViewController, Self: Injectable {
+    /// Register dequeueable cell class for collectionView
+    ///
+    /// - Parameter collectionView: Parent collectionView
+    static func register(to collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
+        CollectionReusableView<Self>.register(to: collectionView, for: kind)
+    }
+    
+    /// Dequeue Injectable cell instance from collectionView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The ViewController's input.
+    ///   - sizeConstraint: Requirement maximum size of Cell.
+    ///   - parentViewController: ParentViewController that must has collectionView.
+    /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return CollectionReusableView<Self>.dequeued(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    }
+}
+
+public extension Instantiatable where Self: UIViewController, Self: Injectable, Self: Emittable {
+    /// Dequeue Injectable/Emittable cell instance from collectionView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The ViewController's input.
+    ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
+    ///   - sizeConstraint: Requirement maximum size of Cell.
+    ///   - parentViewController: ParentViewController that must has collectionView.
+    /// - Returns: The header/footer instance that added the ViewController.
+    static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return CollectionReusableView<Self>.dequeued(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    }
+}
+
+
+// MARK: - CollectionReusableView with UIView
+public extension Instantiatable where Self: UIView, Self: Injectable {
+    /// Register dequeueable cell class for collectionView
+    ///
+    /// - Parameter collectionView: Parent collectionView
+    static func register(to collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
+        ViewController<Self>.register(to: collectionView, for: kind)
+    }
+    
+    /// Dequeue Injectable cell instance from collectionView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The View's input.
+    ///   - sizeConstraint: Requirement maximum size of Cell.
+    ///   - parentViewController: ParentViewController that must has collectionView.
+    /// - Returns: The Cell instance that added the View.
+    static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    }
+}
+
+public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
+    /// Dequeue Injectable/Emittable cell instance from collectionView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The View's input.
+    ///   - output: Handler for View's output. Start handling when cell init. Don't replace handler when cell reused.
+    ///   - sizeConstraint: Requirement maximum size of Cell.
+    ///   - parentViewController: ParentViewController that must has collectionView.
+    /// - Returns: The header/footer instance that added the View.
+    static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    }
+}
+

--- a/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
@@ -52,11 +52,23 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 public extension Injectable where Self: UIView {
     /// Register dequeueable header/footer class for collectionView
     ///
-    /// - Parameter collectionView: Parent collectionView
-    static func registerAsCollectionViewHeaderFooterView<Parent: UIViewController>(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind, parent: Parent.Type) where Parent: Instantiatable {
-        ViewController<Self, Parent>.registerAsCollectionViewHeaderFooterView(on: collectionView, for: kind)
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView
+    ///   - kind: SupplementaryView of kind
+    ///   - environmentType: environment type use when dequeue.
+    static func registerAsCollectionViewHeaderFooterView<Environment>(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind, environmentType: Environment.Type) {
+        ViewController<Self, Environment>.registerAsCollectionViewHeaderFooterView(on: collectionView, for: kind)
     }
     
+    /// Register dequeueable cell class for tableView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView
+    ///   - kind: SupplementaryView of kind
+    ///   - parent: Parent viewController
+    static func registerAsCollectionViewHeaderFooterView<Parent>(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind, parent: Parent) where Parent: Instantiatable {
+        registerAsCollectionViewHeaderFooterView(on: collectionView, for: kind, environmentType: Parent.Environment.self)
+    }
     /// Dequeue Injectable header/footer instance from collectionView
     ///
     /// - Parameters:
@@ -67,7 +79,7 @@ public extension Injectable where Self: UIView {
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the View.
     static func dequeueAsCollectionViewHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable {
-        return ViewController<Self, V>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+        return ViewController<Self, V.Environment>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
@@ -83,7 +95,7 @@ public extension Injectable where Self: UIView, Self: Emittable {
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the View.
     static func dequeueAsCollectionViewHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable {
-        return ViewController<Self, V>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+        return ViewController<Self, V.Environment>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 

--- a/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
@@ -26,7 +26,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueAsCollectionViewHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionReusableView<Self>.dequeued(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
@@ -42,7 +42,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the ViewController.
-    static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueAsCollectionViewHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionReusableView<Self>.dequeued(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
@@ -67,7 +67,7 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the View.
     static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+        return ViewController<Self>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
@@ -83,7 +83,7 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the View.
     static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+        return ViewController<Self>.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 

--- a/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionReusableView+UIKit.swift
@@ -13,7 +13,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     /// Register dequeueable header/footer class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func register(to collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
+    static func registerHeaderFooterView(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
         CollectionReusableView<Self>.register(to: collectionView, for: kind)
     }
     
@@ -26,7 +26,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionReusableView<Self>.dequeued(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
@@ -42,7 +42,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the ViewController.
-    static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionReusableView<Self>.dequeued(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
@@ -53,8 +53,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     /// Register dequeueable header/footer class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func register(to collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
-        ViewController<Self>.register(to: collectionView, for: kind)
+    static func registerHeaderFooterView(on collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
+        ViewController<Self>.registerHeaderFooterView(on: collectionView, for: kind)
     }
     
     /// Dequeue Injectable header/footer instance from collectionView
@@ -66,8 +66,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the View.
-    static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
@@ -82,8 +82,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the View.
-    static func dequeueReusableSupplementaryView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueHeaderFooterView<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionReusableView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 

--- a/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
@@ -13,7 +13,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     /// Register dequeueable cell class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func register(on collectionView: UICollectionView) {
+    static func registerAsCollectionViewCell(on collectionView: UICollectionView) {
         CollectionViewCell<Self>.register(to: collectionView)
     }
 
@@ -52,8 +52,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     /// Register dequeueable cell class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func register(on collectionView: UICollectionView) {
-        ViewController<Self>.register(on: collectionView)
+    static func registerAsCollectionViewCell(on collectionView: UICollectionView) {
+        ViewController<Self>.registerAsCollectionViewCell(on: collectionView)
     }
     
     /// Dequeue Injectable cell instance from collectionView

--- a/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
@@ -13,7 +13,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     /// Register dequeueable cell class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func register(to collectionView: UICollectionView) {
+    static func register(on collectionView: UICollectionView) {
         CollectionViewCell<Self>.register(to: collectionView)
     }
 
@@ -26,7 +26,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueReusableCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionViewCell<Self>.dequeued(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
@@ -42,7 +42,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.
-    static func dequeueReusableCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionViewCell<Self>.dequeued(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
@@ -52,8 +52,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     /// Register dequeueable cell class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func register(to collectionView: UICollectionView) {
-        ViewController<Self>.register(to: collectionView)
+    static func register(on collectionView: UICollectionView) {
+        ViewController<Self>.register(on: collectionView)
     }
     
     /// Dequeue Injectable cell instance from collectionView
@@ -65,8 +65,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueReusableCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueReusableCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
@@ -81,7 +81,7 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.
-    static func dequeueReusableCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueReusableCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }

--- a/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
@@ -26,7 +26,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionViewCell<Self>.dequeued(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
@@ -42,7 +42,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.
-    static func dequeueCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return CollectionViewCell<Self>.dequeued(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
@@ -65,8 +65,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
@@ -81,7 +81,7 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.
-    static func dequeueCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }

--- a/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
@@ -48,12 +48,12 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 }
 
 // MARK: - CollectionViewCell with UIView
-public extension Instantiatable where Self: UIView, Self: Injectable {
+public extension Injectable where Self: UIView {
     /// Register dequeueable cell class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
-    static func registerAsCollectionViewCell(on collectionView: UICollectionView) {
-        ViewController<Self>.registerAsCollectionViewCell(on: collectionView)
+    static func registerAsCollectionViewCell<Parent: UIViewController>(on collectionView: UICollectionView, parent: Parent.Type) where Parent: Instantiatable {
+        ViewController<Self, Parent>.registerAsCollectionViewCell(on: collectionView)
     }
     
     /// Dequeue Injectable cell instance from collectionView
@@ -65,12 +65,12 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable {
+        return ViewController<Self, V>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
-public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
+public extension Injectable where Self: UIView, Self: Emittable {
     /// Dequeue Injectable/Emittable cell instance from collectionView
     ///
     /// - Parameters:
@@ -81,7 +81,7 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.
-    static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable {
+        return ViewController<Self, V>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }

--- a/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
@@ -1,0 +1,87 @@
+//
+//  CollectionViewCell+UIKit.swift
+//  Mew
+//
+//  Created by Shun Usami on 2019/08/28.
+//  Copyright © 2019 Mercari. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - CollectionViewCell with UIViewController
+public extension Instantiatable where Self: UIViewController, Self: Injectable {
+    /// Register dequeueable cell class for collectionView
+    ///
+    /// - Parameter collectionView: Parent collectionView
+    static func register(to collectionView: UICollectionView) {
+        CollectionViewCell<Self>.register(to: collectionView)
+    }
+
+    /// Dequeue Injectable cell instance from collectionView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The ViewController's input.
+    ///   - sizeConstraint: Requirement maximum size of Cell.
+    ///   - parentViewController: ParentViewController that must has collectionView.
+    /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    static func dequeueReusableCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return CollectionViewCell<Self>.dequeued(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    }
+}
+
+public extension Instantiatable where Self: UIViewController, Self: Injectable, Self: Emittable {
+    /// Dequeue Injectable/Emittable cell instance from collectionView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The ViewController's input.
+    ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
+    ///   - sizeConstraint: Requirement maximum size of Cell.
+    ///   - parentViewController: ParentViewController that must has collectionView.
+    /// - Returns: The Cell instance that added the ViewController.
+    static func dequeueReusableCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return CollectionViewCell<Self>.dequeued(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    }
+}
+
+// MARK: - CollectionViewCell with UIView
+public extension Instantiatable where Self: UIView, Self: Injectable {
+    /// Register dequeueable cell class for collectionView
+    ///
+    /// - Parameter collectionView: Parent collectionView
+    static func register(to collectionView: UICollectionView) {
+        ViewController<Self>.register(to: collectionView)
+    }
+    
+    /// Dequeue Injectable cell instance from collectionView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The ViewController's input.
+    ///   - sizeConstraint: Requirement maximum size of Cell.
+    ///   - parentViewController: ParentViewController that must has collectionView.
+    /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    static func dequeueReusableCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueReusableCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    }
+}
+
+public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
+    /// Dequeue Injectable/Emittable cell instance from collectionView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The ViewController's input.
+    ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
+    ///   - sizeConstraint: Requirement maximum size of Cell.
+    ///   - parentViewController: ParentViewController that must has collectionView.
+    /// - Returns: The Cell instance that added the ViewController.
+    static func dequeueReusableCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueReusableCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+    }
+}

--- a/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/CollectionViewCell+UIKit.swift
@@ -51,11 +51,22 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 public extension Injectable where Self: UIView {
     /// Register dequeueable cell class for collectionView
     ///
-    /// - Parameter collectionView: Parent collectionView
-    static func registerAsCollectionViewCell<Parent: UIViewController>(on collectionView: UICollectionView, parent: Parent.Type) where Parent: Instantiatable {
-        ViewController<Self, Parent>.registerAsCollectionViewCell(on: collectionView)
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView
+    ///   - environmentType: environment type use when dequeue.
+    static func registerAsCollectionViewCell<Environment>(on collectionView: UICollectionView, environmentType: Environment.Type) {
+        ViewController<Self, Environment>.registerAsCollectionViewCell(on: collectionView)
     }
     
+    /// Register dequeueable cell class for tableView
+    ///
+    /// - Parameters:
+    ///   - collectionView: Parent collectionView
+    ///   - parent: Parent viewController
+    static func registerAsCollectionViewCell<Parent>(on collectionView: UICollectionView, parent: Parent) where Parent: Instantiatable {
+        registerAsCollectionViewCell(on: collectionView, environmentType: Parent.Environment.self)
+    }
+
     /// Dequeue Injectable cell instance from collectionView
     ///
     /// - Parameters:
@@ -66,7 +77,7 @@ public extension Injectable where Self: UIView {
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
     static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable {
-        return ViewController<Self, V>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+        return ViewController<Self, V.Environment>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }
 
@@ -82,6 +93,6 @@ public extension Injectable where Self: UIView, Self: Emittable {
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.
     static func dequeueAsCollectionViewCell<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> UICollectionViewCell where V: UIViewController, V: Instantiatable {
-        return ViewController<Self, V>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
+        return ViewController<Self, V.Environment>.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: input, output: output, sizeConstraint: sizeConstraint, parentViewController: parentViewController)
     }
 }

--- a/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
@@ -13,7 +13,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     /// Register dequeueable cell class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func register(on tableView: UITableView) {
+    static func registerAsTableViewCell(on tableView: UITableView) {
         TableViewCell<Self>.register(to: tableView)
     }
     
@@ -50,8 +50,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     /// Register dequeueable cell class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func register(on tableView: UITableView) {
-        ViewController<Self>.register(on: tableView)
+    static func registerAsTableViewCell(on tableView: UITableView) {
+        ViewController<Self>.registerAsTableViewCell(on: tableView)
     }
     
     /// Dequeue Injectable cell instance from tableView

--- a/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
@@ -13,7 +13,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     /// Register dequeueable cell class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func register(to tableView: UITableView) {
+    static func register(on tableView: UITableView) {
         TableViewCell<Self>.register(to: tableView)
     }
     
@@ -50,8 +50,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     /// Register dequeueable cell class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func register(to tableView: UITableView) {
-        ViewController<Self>.register(to: tableView)
+    static func register(on tableView: UITableView) {
+        ViewController<Self>.register(on: tableView)
     }
     
     /// Dequeue Injectable cell instance from tableView

--- a/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
@@ -46,12 +46,12 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 }
 
 // MARK: - TableViewCell with UIView
-public extension Instantiatable where Self: UIView, Self: Injectable {
+public extension Injectable where Self: UIView {
     /// Register dequeueable cell class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func registerAsTableViewCell(on tableView: UITableView) {
-        ViewController<Self>.registerAsTableViewCell(on: tableView)
+    static func registerAsTableViewCell<Parent: UIViewController>(on tableView: UITableView, parent: Parent.Type) where Parent: Instantiatable {
+        ViewController<Self, Parent>.registerAsTableViewCell(on: tableView)
     }
     
     /// Dequeue Injectable cell instance from tableView
@@ -62,12 +62,12 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - input: The View's input.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the View.
-    static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
+    static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable {
+        return ViewController<Self, V>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
     }
 }
 
-public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
+public extension Injectable where Self: UIView, Self: Emittable {
     /// Dequeue Injectable/Emittable cell instance from tableView
     ///
     /// - Parameters:
@@ -77,8 +77,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - output: Handler for View's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the View.
-    static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
+    static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable {
+        return ViewController<Self, V>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
     }
 }
 

--- a/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
@@ -25,7 +25,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     ///   - input: The ViewController's input.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return TableViewCell<Self>.dequeued(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
     }
 }
@@ -40,7 +40,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
     ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the ViewController.
-    static func dequeueCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return TableViewCell<Self>.dequeued(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
     }
 }
@@ -62,8 +62,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - input: The View's input.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the View.
-    static func dequeueCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueCell(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
+    static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
     }
 }
 
@@ -77,8 +77,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - output: Handler for View's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the View.
-    static func dequeueCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
+    static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
     }
 }
 

--- a/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
@@ -40,7 +40,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
     ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the ViewController.
-    static func dequeuedCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return TableViewCell<Self>.dequeued(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
     }
 }
@@ -77,8 +77,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - output: Handler for View's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the View.
-    static func dequeuedCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeuedCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
+    static func dequeueCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
     }
 }
 

--- a/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
@@ -49,10 +49,22 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 public extension Injectable where Self: UIView {
     /// Register dequeueable cell class for tableView
     ///
-    /// - Parameter tableView: Parent tableView
-    static func registerAsTableViewCell<Parent: UIViewController>(on tableView: UITableView, parent: Parent.Type) where Parent: Instantiatable {
-        ViewController<Self, Parent>.registerAsTableViewCell(on: tableView)
+    /// - Parameters:
+    ///   - tableView: Parent tableView
+    ///   - environmentType: environment type use when dequeue.
+    static func registerAsTableViewCell<Environment>(on tableView: UITableView, environmentType: Environment.Type) {
+        ViewController<Self, Environment>.registerAsTableViewCell(on: tableView)
     }
+    
+    /// Register dequeueable cell class for tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView
+    ///   - parent: Parent viewController 
+    static func registerAsTableViewCell<Parent>(on tableView: UITableView, parent: Parent) where Parent: Instantiatable {
+        registerAsTableViewCell(on: tableView, environmentType: Parent.Environment.self)
+    }
+    
     
     /// Dequeue Injectable cell instance from tableView
     ///
@@ -63,7 +75,7 @@ public extension Injectable where Self: UIView {
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the View.
     static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable {
-        return ViewController<Self, V>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
+        return ViewController<Self, V.Environment>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
     }
 }
 
@@ -78,7 +90,7 @@ public extension Injectable where Self: UIView, Self: Emittable {
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the View.
     static func dequeueAsTableViewCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable {
-        return ViewController<Self, V>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
+        return ViewController<Self, V.Environment>.dequeueAsTableViewCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
     }
 }
 

--- a/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewCell+UIKit.swift
@@ -1,0 +1,85 @@
+//
+//  TableViewCell+UIKit.swift
+//  Mew
+//
+//  Created by Shun Usami on 2019/08/28.
+//  Copyright © 2019 Mercari. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - TableViewCell with UIViewController
+public extension Instantiatable where Self: UIViewController, Self: Injectable {
+    /// Register dequeueable cell class for tableView
+    ///
+    /// - Parameter tableView: Parent tableView
+    static func register(to tableView: UITableView) {
+        TableViewCell<Self>.register(to: tableView)
+    }
+    
+    /// Dequeue Injectable cell instance from tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The ViewController's input.
+    ///   - parentViewController: ParentViewController that must has tableView.
+    /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    static func dequeueCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return TableViewCell<Self>.dequeued(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
+    }
+}
+
+public extension Instantiatable where Self: UIViewController, Self: Injectable, Self: Emittable {
+    /// Dequeue Injectable/Emittable cell instance from tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The ViewController's input.
+    ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
+    ///   - parentViewController: ParentViewController that must has tableView.
+    /// - Returns: The Cell instance that added the ViewController.
+    static func dequeuedCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return TableViewCell<Self>.dequeued(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
+    }
+}
+
+// MARK: - TableViewCell with UIView
+public extension Instantiatable where Self: UIView, Self: Injectable {
+    /// Register dequeueable cell class for tableView
+    ///
+    /// - Parameter tableView: Parent tableView
+    static func register(to tableView: UITableView) {
+        ViewController<Self>.register(to: tableView)
+    }
+    
+    /// Dequeue Injectable cell instance from tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The View's input.
+    ///   - parentViewController: ParentViewController that must has tableView.
+    /// - Returns: The Cell instance that added the View.
+    static func dequeueCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueCell(from: tableView, for: indexPath, input: input, parentViewController: parentViewController)
+    }
+}
+
+public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
+    /// Dequeue Injectable/Emittable cell instance from tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView that must have registered cell.
+    ///   - indexPath: indexPath for dequeue.
+    ///   - input: The View's input.
+    ///   - output: Handler for View's output. Start handling when cell init. Don't replace handler when cell reused.
+    ///   - parentViewController: ParentViewController that must has tableView.
+    /// - Returns: The Cell instance that added the View.
+    static func dequeuedCell<V>(from tableView: UITableView, for indexPath: IndexPath, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewCell where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeuedCell(from: tableView, for: indexPath, input: input, output: output, parentViewController: parentViewController)
+    }
+}
+
+

--- a/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
@@ -45,12 +45,12 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 
 
 // MARK: - TableViewHeaderFooterView with UIView
-public extension Instantiatable where Self: UIView, Self: Injectable {
+public extension Injectable where Self: UIView {
     /// Register dequeueable header/footer class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func registerAsTableViewHeaderFooterView(on tableView: UITableView) {
-        ViewController<Self>.registerAsTableViewHeaderFooterView(on: tableView)
+    static func registerAsTableViewHeaderFooterView<Parent: UIViewController>(on tableView: UITableView, parent: Parent.Type) where Parent: Instantiatable {
+        ViewController<Self, Parent>.registerAsTableViewHeaderFooterView(on: tableView)
     }
     
     /// Dequeue Injectable header/footer instance from tableView
@@ -60,12 +60,12 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - input: The View's input.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the View.
-    static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, parentViewController: parentViewController)
+    static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable {
+        return ViewController<Self, V>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, parentViewController: parentViewController)
     }
 }
 
-public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
+public extension Injectable where Self: UIView, Self: Emittable {
     /// Dequeue Injectable/Emittable header/footer instance from tableView
     ///
     /// - Parameters:
@@ -74,7 +74,7 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - output: Handler for View's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the View.
-    static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, output: output, parentViewController: parentViewController)
+    static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable {
+        return ViewController<Self, V>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, output: output, parentViewController: parentViewController)
     }
 }

--- a/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
@@ -48,11 +48,22 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
 public extension Injectable where Self: UIView {
     /// Register dequeueable header/footer class for tableView
     ///
-    /// - Parameter tableView: Parent tableView
-    static func registerAsTableViewHeaderFooterView<Parent: UIViewController>(on tableView: UITableView, parent: Parent.Type) where Parent: Instantiatable {
-        ViewController<Self, Parent>.registerAsTableViewHeaderFooterView(on: tableView)
+    /// - Parameters:
+    ///   - tableView: Parent tableView
+    ///   - environmentType: environment type use when dequeue.
+    static func registerAsTableViewHeaderFooterView<Environment>(on tableView: UITableView, environmentType: Environment.Type) {
+        ViewController<Self, Environment>.registerAsTableViewHeaderFooterView(on: tableView)
     }
     
+    /// Register dequeueable cell class for tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView
+    ///   - parent: Parent viewController
+    static func registerAsTableViewHeaderFooterView<Parent>(on tableView: UITableView, parent: Parent) where Parent: Instantiatable {
+        registerAsTableViewHeaderFooterView(on: tableView, environmentType: Parent.Environment.self)
+    }
+
     /// Dequeue Injectable header/footer instance from tableView
     ///
     /// - Parameters:
@@ -61,7 +72,7 @@ public extension Injectable where Self: UIView {
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the View.
     static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable {
-        return ViewController<Self, V>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, parentViewController: parentViewController)
+        return ViewController<Self, V.Environment>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, parentViewController: parentViewController)
     }
 }
 
@@ -75,6 +86,6 @@ public extension Injectable where Self: UIView, Self: Emittable {
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the View.
     static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable {
-        return ViewController<Self, V>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, output: output, parentViewController: parentViewController)
+        return ViewController<Self, V.Environment>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, output: output, parentViewController: parentViewController)
     }
 }

--- a/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
@@ -24,7 +24,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     ///   - input: The ViewController's input.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
-    static func dequeueHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return TableViewHeaderFooterView<Self>.dequeued(from: tableView, input: input, parentViewController: parentViewController)
     }
 }
@@ -38,7 +38,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable, 
     ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the ViewController.
-    static func dequeueHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+    static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
         return TableViewHeaderFooterView<Self>.dequeued(from: tableView, input: input, output: output, parentViewController: parentViewController)
     }
 }
@@ -60,8 +60,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     ///   - input: The View's input.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the View.
-    static func dequeueHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueHeaderFooterView(from: tableView, input: input, parentViewController: parentViewController)
+    static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, parentViewController: parentViewController)
     }
 }
 
@@ -74,7 +74,7 @@ public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emit
     ///   - output: Handler for View's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the View.
-    static func dequeueHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
-        return ViewController<Self>.dequeueHeaderFooterView(from: tableView, input: input, output: output, parentViewController: parentViewController)
+    static func dequeueAsTableViewHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueAsTableViewHeaderFooterView(from: tableView, input: input, output: output, parentViewController: parentViewController)
     }
 }

--- a/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
@@ -13,7 +13,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     /// Register dequeueable header/footer class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func registerHeaderFooterView(on tableView: UITableView) {
+    static func registerAsTableViewHeaderFooterView(on tableView: UITableView) {
         TableViewHeaderFooterView<Self>.register(to: tableView)
     }
     
@@ -49,8 +49,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     /// Register dequeueable header/footer class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func registerHeaderFooterView(on tableView: UITableView) {
-        ViewController<Self>.registerHeaderFooterView(on: tableView)
+    static func registerAsTableViewHeaderFooterView(on tableView: UITableView) {
+        ViewController<Self>.registerAsTableViewHeaderFooterView(on: tableView)
     }
     
     /// Dequeue Injectable header/footer instance from tableView

--- a/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
@@ -13,7 +13,7 @@ public extension Instantiatable where Self: UIViewController, Self: Injectable {
     /// Register dequeueable header/footer class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func registerAsHeaderFooter(to tableView: UITableView) {
+    static func registerHeaderFooterView(on tableView: UITableView) {
         TableViewHeaderFooterView<Self>.register(to: tableView)
     }
     
@@ -49,8 +49,8 @@ public extension Instantiatable where Self: UIView, Self: Injectable {
     /// Register dequeueable header/footer class for tableView
     ///
     /// - Parameter tableView: Parent tableView
-    static func registerAsHeaderFooter(to tableView: UITableView) {
-        ViewController<Self>.registerAsHeaderFooter(to: tableView)
+    static func registerHeaderFooterView(on tableView: UITableView) {
+        ViewController<Self>.registerHeaderFooterView(on: tableView)
     }
     
     /// Dequeue Injectable header/footer instance from tableView

--- a/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
+++ b/Sources/Mew/Cells+UIKit/TableViewHeaderFooterView+UIKit.swift
@@ -1,0 +1,80 @@
+//
+//  TableViewHeaderFooterView+UIKit.swift
+//  Mew
+//
+//  Created by Shun Usami on 2019/08/28.
+//  Copyright © 2019 Mercari. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - TableViewHeaderFooterView with UIViewController
+public extension Instantiatable where Self: UIViewController, Self: Injectable {
+    /// Register dequeueable header/footer class for tableView
+    ///
+    /// - Parameter tableView: Parent tableView
+    static func registerAsHeaderFooter(to tableView: UITableView) {
+        TableViewHeaderFooterView<Self>.register(to: tableView)
+    }
+    
+    /// Dequeue Injectable header/footer instance from tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView that must have registered header/footer.
+    ///   - input: The ViewController's input.
+    ///   - parentViewController: ParentViewController that must has tableView.
+    /// - Returns: The header/footer instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    static func dequeueHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return TableViewHeaderFooterView<Self>.dequeued(from: tableView, input: input, parentViewController: parentViewController)
+    }
+}
+
+public extension Instantiatable where Self: UIViewController, Self: Injectable, Self: Emittable {
+    /// Dequeue Injectable/Emittable header/footer instance from tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView that must have registered header/footer.
+    ///   - input: The ViewController's input.
+    ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
+    ///   - parentViewController: ParentViewController that must has tableView.
+    /// - Returns: The header/footer instance that added the ViewController.
+    static func dequeueHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return TableViewHeaderFooterView<Self>.dequeued(from: tableView, input: input, output: output, parentViewController: parentViewController)
+    }
+}
+
+
+// MARK: - TableViewHeaderFooterView with UIView
+public extension Instantiatable where Self: UIView, Self: Injectable {
+    /// Register dequeueable header/footer class for tableView
+    ///
+    /// - Parameter tableView: Parent tableView
+    static func registerAsHeaderFooter(to tableView: UITableView) {
+        ViewController<Self>.registerAsHeaderFooter(to: tableView)
+    }
+    
+    /// Dequeue Injectable header/footer instance from tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView that must have registered header/footer.
+    ///   - input: The View's input.
+    ///   - parentViewController: ParentViewController that must has tableView.
+    /// - Returns: The header/footer instance that added the View.
+    static func dequeueHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueHeaderFooterView(from: tableView, input: input, parentViewController: parentViewController)
+    }
+}
+
+public extension Instantiatable where Self: UIView, Self: Injectable, Self: Emittable {
+    /// Dequeue Injectable/Emittable header/footer instance from tableView
+    ///
+    /// - Parameters:
+    ///   - tableView: Parent tableView that must have registered header/footer.
+    ///   - input: The View's input.
+    ///   - output: Handler for View's output. Start handling when cell init. Don't replace handler when cell reused.
+    ///   - parentViewController: ParentViewController that must has tableView.
+    /// - Returns: The header/footer instance that added the View.
+    static func dequeueHeaderFooterView<V>(from tableView: UITableView, input: Self.Input, output: ((Self.Output) -> Void)?, parentViewController: V) -> UITableViewHeaderFooterView where V: UIViewController, V: Instantiatable, Self.Environment == V.Environment {
+        return ViewController<Self>.dequeueHeaderFooterView(from: tableView, input: input, output: output, parentViewController: parentViewController)
+    }
+}

--- a/Sources/Mew/Cells+UIKit/ViewController.swift
+++ b/Sources/Mew/Cells+UIKit/ViewController.swift
@@ -1,0 +1,41 @@
+//
+//  TableViewCell+UIView.swift
+//  Mew
+//
+//  Created by Shun Usami on 2019/08/28.
+//  Copyright © 2019 Mercari. All rights reserved.
+//
+
+import UIKit
+
+/// ViewController wrapper for View to use UIView as T of TableViewCell.
+/// T should be `UIView & Injecatble & Instantiatable`
+internal class ViewController<T: UIView>: UIViewController, Instantiatable where T: Instantiatable {
+    typealias Input = T.Input
+    typealias Environment = T.Environment
+    var environment: T.Environment { return content.environment }
+    var content: T
+    required init(with input: Input, environment: Environment) {
+        self.content = T(with: input, environment: environment)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension ViewController: Injectable where T: Injectable {
+    func input(_ input: T.Input) {
+        content.input(input)
+    }
+}
+
+extension ViewController: Emittable where T: Emittable {
+    typealias Output = T.Output
+    func output(_ handler: ((T.Output) -> Void)?) {
+        content.output(handler)
+    }
+}

--- a/Sources/Mew/Cells+UIKit/ViewController.swift
+++ b/Sources/Mew/Cells+UIKit/ViewController.swift
@@ -10,10 +10,9 @@ import UIKit
 
 /// ViewController wrapper for View to use UIView as T of TableViewCell.
 /// T should be `UIView & Injecatble & Instantiatable`
-internal class ViewController<T: UIView, Parent: UIViewController>: UIViewController, Instantiatable where Parent: Instantiatable, T: Injectable {
+internal class ViewController<T: UIView, Environment>: UIViewController, Instantiatable where T: Injectable {
     // MARK: - Instantiatable
     typealias Input = T.Input
-    typealias Environment = Parent.Environment
     var environment: Environment
     var content: T = T(frame: .zero)
     required init(with input: Input, environment: Environment) {

--- a/Sources/Mew/Cells+UIKit/ViewController.swift
+++ b/Sources/Mew/Cells+UIKit/ViewController.swift
@@ -10,13 +10,15 @@ import UIKit
 
 /// ViewController wrapper for View to use UIView as T of TableViewCell.
 /// T should be `UIView & Injecatble & Instantiatable`
-internal class ViewController<T: UIView>: UIViewController, Instantiatable where T: Instantiatable {
+internal class ViewController<T: UIView, Parent: UIViewController>: UIViewController, Instantiatable where Parent: Instantiatable, T: Injectable {
+    // MARK: - Instantiatable
     typealias Input = T.Input
-    typealias Environment = T.Environment
-    var environment: T.Environment { return content.environment }
-    var content: T
+    typealias Environment = Parent.Environment
+    var environment: Environment
+    var content: T = T(frame: .zero)
     required init(with input: Input, environment: Environment) {
-        self.content = T(with: input, environment: environment)
+        self.content.input(input)
+        self.environment = environment
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -24,15 +26,13 @@ internal class ViewController<T: UIView>: UIViewController, Instantiatable where
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
 }
 
-extension ViewController: Injectable where T: Injectable {
+extension ViewController: Injectable {
     func input(_ input: T.Input) {
         content.input(input)
     }
 }
-
 extension ViewController: Emittable where T: Emittable {
     typealias Output = T.Output
     func output(_ handler: ((T.Output) -> Void)?) {

--- a/Sources/Mew/Cells/CollectionReusableView.swift
+++ b/Sources/Mew/Cells/CollectionReusableView.swift
@@ -67,6 +67,7 @@ public extension CollectionReusableView {
     /// Register dequeueable cell class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
+    @available(*, deprecated, message: "Please use YourViewController.register(to:for:) instead")
     static func register(to collectionView: UICollectionView, for kind: CollectionViewSupplementaryKind) {
         collectionView.register(CollectionReusableView.self, forSupplementaryViewOfKind: kind.rawValue, withReuseIdentifier: reuseIdentifier)
     }
@@ -82,6 +83,7 @@ public extension CollectionReusableView where T: Injectable, T: Instantiatable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    @available(*, deprecated, message: "Please use YourViewController.dequeueReusableSupplementaryView(from:of:for:input:sizeConstraint:parentViewController:) instead")
     static func dequeued<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: T.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> CollectionReusableView where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
         let cell = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: CollectionReusableView.reuseIdentifier, for: indexPath) as Any as! CollectionReusableView
@@ -106,6 +108,7 @@ public extension CollectionReusableView where T: Injectable, T: Instantiatable, 
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The header/footer instance that added the ViewController.
+    @available(*, deprecated, message: "Please use YourViewController.dequeueReusableSupplementaryView(from:of:for:input:output:sizeConstraint:parentViewController:) instead")
     static func dequeued<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: T.Input, output: ((T.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> CollectionReusableView where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
         let cell = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: CollectionReusableView.reuseIdentifier, for: indexPath) as Any as! CollectionReusableView

--- a/Sources/Mew/Cells/CollectionReusableView.swift
+++ b/Sources/Mew/Cells/CollectionReusableView.swift
@@ -64,7 +64,7 @@ public class CollectionReusableView<T: UIViewController>: UICollectionReusableVi
 }
 
 public extension CollectionReusableView {
-    /// Register dequeueable cell class for collectionView
+    /// Register dequeueable header/footer class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
     @available(*, deprecated, message: "Please use YourViewController.register(to:for:) instead")
@@ -74,7 +74,7 @@ public extension CollectionReusableView {
 }
 
 public extension CollectionReusableView where T: Injectable, T: Instantiatable {
-    /// Dequeue cell instance from collectionView
+    /// Dequeue header/footer instance from collectionView
     ///
     /// - Parameters:
     ///   - collectionView: Parent collectionView that must have registered cell.
@@ -82,7 +82,7 @@ public extension CollectionReusableView where T: Injectable, T: Instantiatable {
     ///   - input: The ViewController's input.
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
-    /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    /// - Returns: The header/footer instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
     @available(*, deprecated, message: "Please use YourViewController.dequeueReusableSupplementaryView(from:of:for:input:sizeConstraint:parentViewController:) instead")
     static func dequeued<V>(from collectionView: UICollectionView, of kind: String, for indexPath: IndexPath, input: T.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> CollectionReusableView where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
@@ -98,7 +98,7 @@ public extension CollectionReusableView where T: Injectable, T: Instantiatable {
 }
 
 public extension CollectionReusableView where T: Injectable, T: Instantiatable, T: Emittable {
-    /// Dequeue cell instance from collectionView
+    /// Dequeue header/footer instance from collectionView
     ///
     /// - Parameters:
     ///   - collectionView: Parent collectionView that must have registered cell.

--- a/Sources/Mew/Cells/CollectionViewCell.swift
+++ b/Sources/Mew/Cells/CollectionViewCell.swift
@@ -51,6 +51,7 @@ public extension CollectionViewCell {
     /// Register dequeueable cell class for collectionView
     ///
     /// - Parameter collectionView: Parent collectionView
+    @available(*, deprecated, message: "Please use YourViewController.register(to:)")
     static func register(to collectionView: UICollectionView) {
         collectionView.register(CollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
     }
@@ -66,6 +67,7 @@ public extension CollectionViewCell where T: Injectable, T: Instantiatable {
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    @available(*, deprecated, message: "Please use YourViewController.dequeueReusableSupplementaryView(from:for:input:sizeConstraint:parentViewController:) instead")
     static func dequeued<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: T.Input, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> CollectionViewCell where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionViewCell.reuseIdentifier, for: indexPath) as Any as! CollectionViewCell
@@ -90,6 +92,7 @@ public extension CollectionViewCell where T: Injectable, T: Instantiatable, T: E
     ///   - sizeConstraint: Requirement maximum size of Cell.
     ///   - parentViewController: ParentViewController that must has collectionView.
     /// - Returns: The Cell instance that added the ViewController.
+    @available(*, deprecated, message: "Please use YourViewController.dequeueReusableSupplementaryView(from:for:input:output:sizeConstraint:parentViewController:) instead")
     static func dequeued<V>(from collectionView: UICollectionView, for indexPath: IndexPath, input: T.Input, output: ((T.Output) -> Void)?, sizeConstraint: SizeConstraint? = nil, parentViewController: V) -> CollectionViewCell where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionViewCell.reuseIdentifier, for: indexPath) as Any as! CollectionViewCell

--- a/Sources/Mew/Cells/TableViewCell.swift
+++ b/Sources/Mew/Cells/TableViewCell.swift
@@ -46,6 +46,7 @@ public extension TableViewCell {
     /// Register dequeueable cell class for tableView
     ///
     /// - Parameter tableView: Parent tableView
+    @available(*, deprecated, message: "Please use YourViewController.register(to:) instead")
     static func register(to tableView: UITableView) {
         tableView.register(TableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
     }
@@ -60,6 +61,7 @@ public extension TableViewCell where T: Injectable, T: Instantiatable {
     ///   - input: The ViewController's input.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    @available(*, deprecated, message: "Please use YourViewController.dequeueCell(from:input:parentViewController:) instead")
     static func dequeued<V>(from tableView: UITableView, for indexPath: IndexPath, input: T.Input, parentViewController: V) -> TableViewCell where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
         let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.reuseIdentifier, for: indexPath) as Any as! TableViewCell
@@ -83,6 +85,7 @@ public extension TableViewCell where T: Injectable, T: Instantiatable, T: Emitta
     ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The Cell instance that added the ViewController.
+    @available(*, deprecated, message: "Please use YourViewController.dequeueCell(from:input:output:parentViewController:) instead")
     static func dequeued<V>(from tableView: UITableView, for indexPath: IndexPath, input: T.Input, output: ((T.Output) -> Void)?, parentViewController: V) -> TableViewCell where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
         let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.reuseIdentifier, for: indexPath) as Any as! TableViewCell

--- a/Sources/Mew/Cells/TableViewHeaderFooterView.swift
+++ b/Sources/Mew/Cells/TableViewHeaderFooterView.swift
@@ -55,6 +55,7 @@ public extension TableViewHeaderFooterView {
     /// Register dequeueable header/footer class for tableView
     ///
     /// - Parameter tableView: Parent tableView
+    @available(*, deprecated, message: "Please use YourViewController.registerAsHeaderFooter(to:) instead")
     static func register(to tableView: UITableView) {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: reuseIdentifier)
     }
@@ -68,6 +69,7 @@ public extension TableViewHeaderFooterView where T: Injectable, T: Instantiatabl
     ///   - input: The ViewController's input.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the ViewController.view, and the ViewController have injected dependency, VC hierarchy.
+    @available(*, deprecated, message: "Please use YourViewController.dequeueHeaderFooterView(from:input:parentViewController:) instead")
     static func dequeued<V>(from tableView: UITableView, input: T.Input, parentViewController: V) -> TableViewHeaderFooterView where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
         let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.reuseIdentifier) as Any as! TableViewHeaderFooterView
@@ -89,6 +91,7 @@ public extension TableViewHeaderFooterView where T: Injectable, T: Instantiatabl
     ///   - output: Handler for ViewController's output. Start handling when cell init. Don't replace handler when cell reused.
     ///   - parentViewController: ParentViewController that must has tableView.
     /// - Returns: The header/footer instance that added the ViewController.
+    @available(*, deprecated, message: "Please use YourViewController.dequeueHeaderFooterView(from:input:output:parentViewController:) instead")
     static func dequeued<V>(from tableView: UITableView, input: T.Input, output: ((T.Output) -> Void)?, parentViewController: V) -> TableViewHeaderFooterView where V: UIViewController, V: Instantiatable, T.Environment == V.Environment {
         // Swift4.1 has bug that `Cast from 'X' to unrelated type 'Y<T>' always fails` if T is class and has protocol condition.
         let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.reuseIdentifier) as Any as! TableViewHeaderFooterView

--- a/Tests/MewTests/CollectionViewCellTests.swift
+++ b/Tests/MewTests/CollectionViewCellTests.swift
@@ -151,10 +151,10 @@ class CollectionViewCellTests: XCTestCase {
                 let cells = collectionViewController.collectionView!.indexPathsForVisibleItems.sorted().compactMap { collectionViewController.collectionView!.cellForItem(at: $0) }
                 zip(expects, cells).forEach { expect, cell in
                     let expectedSize = CGSize(width: min(collectionViewController.collectionView!.frame.width - 40.0, 200 + expect.additionalWidth), height: 200 + expect.additionalHeight)
-                    XCTAssertEqual(cell.frame.size, expectedSize)
-                    XCTAssertEqual(cell.contentView.frame.size, expectedSize)
+                    XCTAssertEqual(cell.frame.size, expectedSize, accurancy: 1.0)
+                    XCTAssertEqual(cell.contentView.frame.size, expectedSize, accurancy: 1.0)
                     let childViewController = collectionViewController.children.first(where: { $0.view.superview == cell.contentView }) as! AutolayoutViewController
-                    XCTAssertEqual(childViewController.view.frame.size, expectedSize)
+                    XCTAssertEqual(childViewController.view.frame.size, expectedSize, accurancy: 1.0)
                     XCTAssertFalse(cell.hasAmbiguousLayout)
                 }
             }
@@ -171,10 +171,10 @@ class CollectionViewCellTests: XCTestCase {
                 let cells = collectionViewController.collectionView!.indexPathsForVisibleItems.sorted().compactMap { collectionViewController.collectionView!.cellForItem(at: $0) }
                 zip(expects, cells).forEach { expect, cell in
                     let expectedSize = CGSize(width: 200 + expect.additionalWidth, height: min(collectionViewController.collectionView!.frame.height - 40.0, 200 + expect.additionalHeight))
-                    XCTAssertEqual(cell.frame.size, expectedSize)
-                    XCTAssertEqual(cell.contentView.frame.size, expectedSize)
+                    XCTAssertEqual(cell.frame.size, expectedSize, accurancy: 1.0)
+                    XCTAssertEqual(cell.contentView.frame.size, expectedSize, accurancy: 1.0)
                     let childViewController = collectionViewController.children.first(where: { $0.view.superview == cell.contentView }) as! AutolayoutViewController
-                    XCTAssertEqual(childViewController.view.frame.size, expectedSize)
+                    XCTAssertEqual(childViewController.view.frame.size, expectedSize, accurancy: 1.0)
                     XCTAssertFalse(cell.hasAmbiguousLayout)
                 }
             }

--- a/Tests/MewTests/CollectionViewCellTests.swift
+++ b/Tests/MewTests/CollectionViewCellTests.swift
@@ -20,7 +20,7 @@ class CollectionViewCellTests: XCTestCase {
         }
 
         INJECTABLE_VIEW: do {
-            let cell = View.dequeueAsCollectionViewCell(from: collectionViewController.collectionView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController) as! CollectionViewCell<Mew.ViewController<View, CollectionViewController>>
+            let cell = View.dequeueAsCollectionViewCell(from: collectionViewController.collectionView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController) as! CollectionViewCell<Mew.ViewController<View, Void>>
             XCTAssertEqual(cell.content.content.parameter, 39)
             XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
         }
@@ -37,7 +37,7 @@ class CollectionViewCellTests: XCTestCase {
 
         INTERACTABLE_VIEW: do {
             var expected: Int?
-            let cell = View.dequeueAsCollectionViewCell(from: collectionViewController.collectionView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController) as! CollectionViewCell<Mew.ViewController<View, CollectionViewController>>
+            let cell = View.dequeueAsCollectionViewCell(from: collectionViewController.collectionView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController) as! CollectionViewCell<Mew.ViewController<View, Void>>
             XCTAssertEqual(cell.content.content.parameter, 48)
             XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
             XCTAssertNil(expected)
@@ -56,7 +56,7 @@ class CollectionViewCellTests: XCTestCase {
         }
 
         INJECTABLE_VIEW: do {
-            let view = View.dequeueAsCollectionViewHeaderFooterView(from: collectionViewController.collectionView, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController) as! CollectionReusableView<Mew.ViewController<View, CollectionViewController>>
+            let view = View.dequeueAsCollectionViewHeaderFooterView(from: collectionViewController.collectionView, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController) as! CollectionReusableView<Mew.ViewController<View, Void>>
             XCTAssertEqual(view.content.content.parameter, 39)
             XCTAssertTrue(view.subviewTreeContains(with: view.content.view))
         }
@@ -73,7 +73,7 @@ class CollectionViewCellTests: XCTestCase {
 
         INTERACTABLE_VIEW: do {
             var expected: Int?
-            let view = View.dequeueAsCollectionViewHeaderFooterView(from: collectionViewController.collectionView, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController) as! CollectionReusableView<Mew.ViewController<View, CollectionViewController>>
+            let view = View.dequeueAsCollectionViewHeaderFooterView(from: collectionViewController.collectionView, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController) as! CollectionReusableView<Mew.ViewController<View, Void>>
             XCTAssertEqual(view.content.content.parameter, 48)
             XCTAssertTrue(view.subviewTreeContains(with: view.content.view))
             XCTAssertNil(expected)
@@ -100,7 +100,7 @@ class CollectionViewCellTests: XCTestCase {
                 collectionViewController
             )
             XCTAssertEqual(
-                (collectionViewController.collectionView?.supplementaryView(forElementKind: CollectionViewSupplementaryKind.header.rawValue, at: IndexPath(item: 0, section: 1)) as? CollectionReusableView<Mew.ViewController<View, CollectionViewController>>)?.content.parent,
+                (collectionViewController.collectionView?.supplementaryView(forElementKind: CollectionViewSupplementaryKind.header.rawValue, at: IndexPath(item: 0, section: 1)) as? CollectionReusableView<Mew.ViewController<View, Void>>)?.content.parent,
                 collectionViewController
             )
             parent.dismiss(animated: true, completion: {

--- a/Tests/MewTests/CollectionViewCellTests.swift
+++ b/Tests/MewTests/CollectionViewCellTests.swift
@@ -13,19 +13,35 @@ class CollectionViewCellTests: XCTestCase {
     func testDequeueCollectionViewCellWithViewController() {
         let collectionViewController = CollectionViewController(with: [1, 2, 3], environment: ())
         _ = collectionViewController.view // load view
-        INJECTABLE: do {
-            let cell = CollectionViewCell<ViewController>.dequeued(from: collectionViewController.collectionView!, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController)
+        INJECTABLE_VC: do {
+            let cell = ViewController.dequeueAsCollectionViewCell(from: collectionViewController.collectionView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController) as! CollectionViewCell<ViewController>
             XCTAssertEqual(cell.content.parameter, 39)
             XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
         }
 
-        INTERACTABLE: do {
+        INJECTABLE_VIEW: do {
+            let cell = View.dequeueAsCollectionViewCell(from: collectionViewController.collectionView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController) as! CollectionViewCell<Mew.ViewController<View, CollectionViewController>>
+            XCTAssertEqual(cell.content.content.parameter, 39)
+            XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
+        }
+
+        INTERACTABLE_VC: do {
             var expected: Int?
-            let cell = CollectionViewCell<ViewController>.dequeued(from: collectionViewController.collectionView!, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController)
+            let cell = ViewController.dequeueAsCollectionViewCell(from: collectionViewController.collectionView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController) as! CollectionViewCell<ViewController>
             XCTAssertEqual(cell.content.parameter, 48)
             XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
             XCTAssertNil(expected)
             cell.content.fire()
+            XCTAssertEqual(expected, 48)
+        }
+
+        INTERACTABLE_VIEW: do {
+            var expected: Int?
+            let cell = View.dequeueAsCollectionViewCell(from: collectionViewController.collectionView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController) as! CollectionViewCell<Mew.ViewController<View, CollectionViewController>>
+            XCTAssertEqual(cell.content.content.parameter, 48)
+            XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
+            XCTAssertNil(expected)
+            cell.content.content.fire()
             XCTAssertEqual(expected, 48)
         }
     }
@@ -33,19 +49,35 @@ class CollectionViewCellTests: XCTestCase {
     func testDequeueCollectionViewHeaderFooterWithViewController() {
         let collectionViewController = CollectionViewController(with: [1, 2, 3], environment: ())
         _ = collectionViewController.view // load view
-        INJECTABLE: do {
-            let view = CollectionReusableView<ViewController>.dequeued(from: collectionViewController.collectionView!, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(item: 0, section: 0), input: 39, parentViewController: collectionViewController)
+        INJECTABLE_VC: do {
+            let view = ViewController.dequeueAsCollectionViewHeaderFooterView(from: collectionViewController.collectionView, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController) as! CollectionReusableView<ViewController>
             XCTAssertEqual(view.content.parameter, 39)
             XCTAssertTrue(view.subviewTreeContains(with: view.content.view))
         }
 
-        INTERACTABLE: do {
+        INJECTABLE_VIEW: do {
+            let view = View.dequeueAsCollectionViewHeaderFooterView(from: collectionViewController.collectionView, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: collectionViewController) as! CollectionReusableView<Mew.ViewController<View, CollectionViewController>>
+            XCTAssertEqual(view.content.content.parameter, 39)
+            XCTAssertTrue(view.subviewTreeContains(with: view.content.view))
+        }
+
+        INTERACTABLE_VC: do {
             var expected: Int?
-            let view = CollectionReusableView<ViewController>.dequeued(from: collectionViewController.collectionView!, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(item: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController)
+            let view = ViewController.dequeueAsCollectionViewHeaderFooterView(from: collectionViewController.collectionView, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController) as! CollectionReusableView<ViewController>
             XCTAssertEqual(view.content.parameter, 48)
             XCTAssertTrue(view.subviewTreeContains(with: view.content.view))
             XCTAssertNil(expected)
             view.content.fire()
+            XCTAssertEqual(expected, 48)
+        }
+
+        INTERACTABLE_VIEW: do {
+            var expected: Int?
+            let view = View.dequeueAsCollectionViewHeaderFooterView(from: collectionViewController.collectionView, of: CollectionViewSupplementaryKind.header.rawValue, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: collectionViewController) as! CollectionReusableView<Mew.ViewController<View, CollectionViewController>>
+            XCTAssertEqual(view.content.content.parameter, 48)
+            XCTAssertTrue(view.subviewTreeContains(with: view.content.view))
+            XCTAssertNil(expected)
+            view.content.content.fire()
             XCTAssertEqual(expected, 48)
         }
     }
@@ -65,6 +97,10 @@ class CollectionViewCellTests: XCTestCase {
             }
             XCTAssertEqual(
                 (collectionViewController.collectionView?.supplementaryView(forElementKind: CollectionViewSupplementaryKind.header.rawValue, at: IndexPath(item: 0, section: 0)) as? CollectionReusableView<ViewController>)?.content.parent,
+                collectionViewController
+            )
+            XCTAssertEqual(
+                (collectionViewController.collectionView?.supplementaryView(forElementKind: CollectionViewSupplementaryKind.header.rawValue, at: IndexPath(item: 0, section: 1)) as? CollectionReusableView<Mew.ViewController<View, CollectionViewController>>)?.content.parent,
                 collectionViewController
             )
             parent.dismiss(animated: true, completion: {

--- a/Tests/MewTests/Supports.swift
+++ b/Tests/MewTests/Supports.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Mew
+import XCTest
 
 extension UIView {
     private static func contains(_ view: UIView, where condition: (UIView) -> Bool) -> Bool {
@@ -381,4 +382,9 @@ final class AutolayoutCollectionViewController: UICollectionViewController, Inst
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         return AutolayoutViewController.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
+}
+
+func XCTAssertEqual(_ expression1: CGSize, _ expression2: CGSize, accurancy: CGFloat, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(expression1.height, expression2.height, accuracy: accurancy, file: file, line: line)
+    XCTAssertEqual(expression1.width, expression2.width, accuracy: accurancy, file: file, line: line)
 }

--- a/Tests/MewTests/Supports.swift
+++ b/Tests/MewTests/Supports.swift
@@ -90,8 +90,8 @@ final class TableViewController: UITableViewController, Instantiatable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        TableViewCell<ViewController>.register(to: tableView)
-        TableViewHeaderFooterView<ViewController>.register(to: tableView)
+        ViewController.register(to: tableView)
+        ViewController.registerAsHeaderFooter(to: tableView)
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -103,11 +103,11 @@ final class TableViewController: UITableViewController, Instantiatable {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return TableViewCell<ViewController>.dequeued(from: tableView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return ViewController.dequeueCell(from: tableView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return TableViewHeaderFooterView<ViewController>.dequeued(from: tableView, input: elements.count, parentViewController: self)
+        return ViewController.dequeueHeaderFooterView(from: tableView, input: elements.count, parentViewController: self)
     }
 }
 
@@ -127,8 +127,8 @@ final class CollectionViewController: UICollectionViewController, Instantiatable
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        CollectionViewCell<ViewController>.register(to: collectionView!)
-        CollectionReusableView<ViewController>.register(to: collectionView!, for: .header)
+        ViewController.register(to: collectionView!)
+        ViewController.register(to: collectionView!, for: .header)
         collectionViewLayout.invalidateLayout()
         collectionView?.reloadData()
         collectionView?.layoutIfNeeded()
@@ -143,11 +143,11 @@ final class CollectionViewController: UICollectionViewController, Instantiatable
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return CollectionViewCell<ViewController>.dequeued(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return ViewController.dequeueReusableCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 
     override func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        return CollectionReusableView<ViewController>.dequeued(from: collectionView, of: kind, for: indexPath, input: elements.count, parentViewController: self)
+        return ViewController.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: elements.count, parentViewController: self)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
@@ -256,7 +256,7 @@ final class AutolayoutTableViewController: UITableViewController, Instantiatable
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        TableViewCell<AutolayoutViewController>.register(to: tableView)
+        AutolayoutViewController.register(to: tableView)
     }
 
     func input(_ input: [AutolayoutViewController.Input]) {
@@ -273,7 +273,7 @@ final class AutolayoutTableViewController: UITableViewController, Instantiatable
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return TableViewCell<AutolayoutViewController>.dequeued(from: tableView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return AutolayoutViewController.dequeueCell(from: tableView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 }
 
@@ -295,7 +295,7 @@ final class AutolayoutCollectionViewController: UICollectionViewController, Inst
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        CollectionViewCell<AutolayoutViewController>.register(to: collectionView!)
+        AutolayoutViewController.register(to: collectionView!)
         if #available(iOS 10.0, *) {
             flowLayout.itemSize = UICollectionViewFlowLayout.automaticSize
         }
@@ -317,6 +317,6 @@ final class AutolayoutCollectionViewController: UICollectionViewController, Inst
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return CollectionViewCell<AutolayoutViewController>.dequeued(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return AutolayoutViewController.dequeueReusableCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 }

--- a/Tests/MewTests/Supports.swift
+++ b/Tests/MewTests/Supports.swift
@@ -103,11 +103,11 @@ final class TableViewController: UITableViewController, Instantiatable {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return ViewController.dequeueCell(from: tableView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return ViewController.dequeueAsTableViewCell(from: tableView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return ViewController.dequeueHeaderFooterView(from: tableView, input: elements.count, parentViewController: self)
+        return ViewController.dequeueAsTableViewHeaderFooterView(from: tableView, input: elements.count, parentViewController: self)
     }
 }
 
@@ -143,11 +143,11 @@ final class CollectionViewController: UICollectionViewController, Instantiatable
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return ViewController.dequeueCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return ViewController.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 
     override func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        return ViewController.dequeueHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: elements.count, parentViewController: self)
+        return ViewController.dequeueAsCollectionViewHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: elements.count, parentViewController: self)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
@@ -273,7 +273,7 @@ final class AutolayoutTableViewController: UITableViewController, Instantiatable
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return AutolayoutViewController.dequeueCell(from: tableView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return AutolayoutViewController.dequeueAsTableViewCell(from: tableView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 }
 
@@ -317,6 +317,6 @@ final class AutolayoutCollectionViewController: UICollectionViewController, Inst
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return AutolayoutViewController.dequeueCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return AutolayoutViewController.dequeueAsCollectionViewCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 }

--- a/Tests/MewTests/Supports.swift
+++ b/Tests/MewTests/Supports.swift
@@ -90,8 +90,8 @@ final class TableViewController: UITableViewController, Instantiatable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        ViewController.register(to: tableView)
-        ViewController.registerAsHeaderFooter(to: tableView)
+        ViewController.register(on: tableView)
+        ViewController.registerHeaderFooterView(on: tableView)
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -127,8 +127,8 @@ final class CollectionViewController: UICollectionViewController, Instantiatable
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        ViewController.register(to: collectionView!)
-        ViewController.register(to: collectionView!, for: .header)
+        ViewController.register(on: collectionView!)
+        ViewController.registerHeaderFooterView(on: collectionView!, for: .header)
         collectionViewLayout.invalidateLayout()
         collectionView?.reloadData()
         collectionView?.layoutIfNeeded()
@@ -143,11 +143,11 @@ final class CollectionViewController: UICollectionViewController, Instantiatable
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return ViewController.dequeueReusableCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return ViewController.dequeueCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 
     override func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        return ViewController.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: elements.count, parentViewController: self)
+        return ViewController.dequeueHeaderFooterView(from: collectionView, of: kind, for: indexPath, input: elements.count, parentViewController: self)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
@@ -256,7 +256,7 @@ final class AutolayoutTableViewController: UITableViewController, Instantiatable
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        AutolayoutViewController.register(to: tableView)
+        AutolayoutViewController.register(on: tableView)
     }
 
     func input(_ input: [AutolayoutViewController.Input]) {
@@ -295,7 +295,7 @@ final class AutolayoutCollectionViewController: UICollectionViewController, Inst
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        AutolayoutViewController.register(to: collectionView!)
+        AutolayoutViewController.register(on: collectionView!)
         if #available(iOS 10.0, *) {
             flowLayout.itemSize = UICollectionViewFlowLayout.automaticSize
         }
@@ -317,6 +317,6 @@ final class AutolayoutCollectionViewController: UICollectionViewController, Inst
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return AutolayoutViewController.dequeueReusableCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
+        return AutolayoutViewController.dequeueCell(from: collectionView, for: indexPath, input: elements[indexPath.row], parentViewController: self)
     }
 }

--- a/Tests/MewTests/Supports.swift
+++ b/Tests/MewTests/Supports.swift
@@ -90,8 +90,8 @@ final class TableViewController: UITableViewController, Instantiatable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        ViewController.register(on: tableView)
-        ViewController.registerHeaderFooterView(on: tableView)
+        ViewController.registerAsTableViewCell(on: tableView)
+        ViewController.registerAsTableViewHeaderFooterView(on: tableView)
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -127,8 +127,8 @@ final class CollectionViewController: UICollectionViewController, Instantiatable
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        ViewController.register(on: collectionView!)
-        ViewController.registerHeaderFooterView(on: collectionView!, for: .header)
+        ViewController.registerAsCollectionViewCell(on: collectionView!)
+        ViewController.registerAsCollectionViewHeaderFooterView(on: collectionView!, for: .header)
         collectionViewLayout.invalidateLayout()
         collectionView?.reloadData()
         collectionView?.layoutIfNeeded()
@@ -256,7 +256,7 @@ final class AutolayoutTableViewController: UITableViewController, Instantiatable
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        AutolayoutViewController.register(on: tableView)
+        AutolayoutViewController.registerAsTableViewCell(on: tableView)
     }
 
     func input(_ input: [AutolayoutViewController.Input]) {
@@ -295,7 +295,7 @@ final class AutolayoutCollectionViewController: UICollectionViewController, Inst
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        AutolayoutViewController.register(on: collectionView!)
+        AutolayoutViewController.registerAsCollectionViewCell(on: collectionView!)
         if #available(iOS 10.0, *) {
             flowLayout.itemSize = UICollectionViewFlowLayout.automaticSize
         }

--- a/Tests/MewTests/Supports.swift
+++ b/Tests/MewTests/Supports.swift
@@ -126,8 +126,8 @@ final class TableViewController: UITableViewController, Instantiatable {
         super.viewDidLoad()
         ViewController.registerAsTableViewCell(on: tableView)
         ViewController.registerAsTableViewHeaderFooterView(on: tableView)
-        View.registerAsTableViewCell(on: tableView, parent: type(of: self))
-        View.registerAsTableViewHeaderFooterView(on: tableView, parent: type(of: self))
+        View.registerAsTableViewCell(on: tableView, parent: self)
+        View.registerAsTableViewHeaderFooterView(on: tableView, parent: self)
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -179,8 +179,8 @@ final class CollectionViewController: UICollectionViewController, Instantiatable
         super.viewDidLoad()
         ViewController.registerAsCollectionViewCell(on: collectionView!)
         ViewController.registerAsCollectionViewHeaderFooterView(on: collectionView!, for: .header)
-        View.registerAsCollectionViewCell(on: collectionView!, parent: type(of: self))
-        View.registerAsCollectionViewHeaderFooterView(on: collectionView!, for: .header, parent: type(of: self))
+        View.registerAsCollectionViewCell(on: collectionView!, parent: self)
+        View.registerAsCollectionViewHeaderFooterView(on: collectionView!, for: .header, parent: self)
         collectionViewLayout.invalidateLayout()
         collectionView?.reloadData()
         collectionView?.layoutIfNeeded()

--- a/Tests/MewTests/TableViewCellTests.swift
+++ b/Tests/MewTests/TableViewCellTests.swift
@@ -13,8 +13,8 @@ class TableViewCellTests: XCTestCase {
     func testDequeueTableViewCellWithViewController() {
         let tableViewController = TableViewController(with: [1, 2, 3], environment: ())
         _ = tableViewController.view // load view
-        INJECTABLE: do {
-            let cell = TableViewCell<ViewController>.dequeued(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: tableViewController)
+        INJECTABLE_VC: do {
+            let cell = ViewController.dequeueAsTableViewCell(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: tableViewController) as! TableViewCell<ViewController>
             XCTAssertEqual(cell.content.parameter, 39)
             XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
             XCTAssertEqual(cell.accessoryType, .none)
@@ -22,9 +22,18 @@ class TableViewCellTests: XCTestCase {
             XCTAssertEqual(cell.selectionStyle, .none)
         }
 
-        INTERACTABLE: do {
+        INJECTABLE_VIEW: do {
+            let cell = View.dequeueAsTableViewCell(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: tableViewController) as! TableViewCell<Mew.ViewController<View, TableViewController>>
+            XCTAssertEqual(cell.content.content.parameter, 39)
+            XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
+            XCTAssertEqual(cell.accessoryType, .none)
+            XCTAssertEqual(cell.editingAccessoryType, .none)
+            XCTAssertEqual(cell.selectionStyle, .none)
+        }
+
+        INTERACTABLE_VC: do {
             var expected: Int?
-            let cell = TableViewCell<ViewController>.dequeued(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: tableViewController)
+            let cell = ViewController.dequeueAsTableViewCell(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: tableViewController) as! TableViewCell<ViewController>
             XCTAssertEqual(cell.content.parameter, 48)
             XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
             XCTAssertEqual(cell.accessoryType, .none)
@@ -34,24 +43,53 @@ class TableViewCellTests: XCTestCase {
             cell.content.fire()
             XCTAssertEqual(expected, 48)
         }
+
+        INTERACTABLE_VIEW: do {
+            var expected: Int?
+            let cell = View.dequeueAsTableViewCell(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: tableViewController) as! TableViewCell<Mew.ViewController<View, TableViewController>>
+            XCTAssertEqual(cell.content.content.parameter, 48)
+            XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
+            XCTAssertEqual(cell.accessoryType, .none)
+            XCTAssertEqual(cell.editingAccessoryType, .none)
+            XCTAssertEqual(cell.selectionStyle, .none)
+            XCTAssertNil(expected)
+            cell.content.content.fire()
+            XCTAssertEqual(expected, 48)
+        }
     }
 
     func testDequeueTableViewHeaderFooterWithViewController() {
         let tableViewController = TableViewController(with: [1, 2, 3], environment: ())
         _ = tableViewController.view // load view
-        INJECTABLE: do {
-            let view = TableViewHeaderFooterView<ViewController>.dequeued(from: tableViewController.tableView, input: 39, parentViewController: tableViewController)
+        INJECTABLE_VC: do {
+            let view = ViewController.dequeueAsTableViewHeaderFooterView(from: tableViewController.tableView, input: 39, parentViewController: tableViewController) as! TableViewHeaderFooterView<ViewController>
             XCTAssertEqual(view.content.parameter, 39)
             XCTAssertTrue(view.contentView.subviewTreeContains(with: view.content.view))
         }
 
-        INTERACTABLE: do {
+        INJECTABLE_VIEW: do {
+            let view = View.dequeueAsTableViewHeaderFooterView(from: tableViewController.tableView, input: 39, parentViewController: tableViewController) as! TableViewHeaderFooterView<Mew.ViewController<View, TableViewController>>
+            XCTAssertEqual(view.content.content.parameter, 39)
+            XCTAssertTrue(view.contentView.subviewTreeContains(with: view.content.view))
+        }
+
+        INTERACTABLE_VC: do {
             var expected: Int?
-            let view = TableViewHeaderFooterView<ViewController>.dequeued(from: tableViewController.tableView, input: 48, output: { expected = $0 }, parentViewController: tableViewController)
+            let view = ViewController.dequeueAsTableViewHeaderFooterView(from: tableViewController.tableView, input: 48, output: { expected = $0 }, parentViewController: tableViewController) as! TableViewHeaderFooterView<ViewController>
             XCTAssertEqual(view.content.parameter, 48)
             XCTAssertTrue(view.contentView.subviewTreeContains(with: view.content.view))
             XCTAssertNil(expected)
             view.content.fire()
+            XCTAssertEqual(expected, 48)
+        }
+
+        INTERACTABLE_VIEW: do {
+            var expected: Int?
+            let view = View.dequeueAsTableViewHeaderFooterView(from: tableViewController.tableView, input: 48, output: { expected = $0 }, parentViewController: tableViewController) as! TableViewHeaderFooterView<Mew.ViewController<View, TableViewController>>
+            XCTAssertEqual(view.content.content.parameter, 48)
+            XCTAssertTrue(view.contentView.subviewTreeContains(with: view.content.view))
+            XCTAssertNil(expected)
+            view.content.content.fire()
             XCTAssertEqual(expected, 48)
         }
     }
@@ -71,6 +109,10 @@ class TableViewCellTests: XCTestCase {
             }
             XCTAssertEqual(
                 (tableViewController.tableView.headerView(forSection: 0) as? TableViewHeaderFooterView<ViewController>)?.content.parent,
+                tableViewController
+            )
+            XCTAssertEqual(
+                (tableViewController.tableView.headerView(forSection: 1) as? TableViewHeaderFooterView<Mew.ViewController<View, TableViewController>>)?.content.parent,
                 tableViewController
             )
             parent.dismiss(animated: true, completion: {

--- a/Tests/MewTests/TableViewCellTests.swift
+++ b/Tests/MewTests/TableViewCellTests.swift
@@ -158,10 +158,10 @@ class TableViewCellTests: XCTestCase {
             tableViewController.input(expects)
             let cells = tableViewController.tableView.visibleCells
             zip(expects, cells).forEach { expect, cell in
-                XCTAssertEqual(cell.frame.size, CGSize(width: tableViewController.tableView.frame.width, height: 200 + expect.additionalHeight + 0.5))
-                XCTAssertEqual(cell.contentView.frame.size, CGSize(width: tableViewController.tableView.frame.width, height: 200 + expect.additionalHeight))
+                XCTAssertEqual(cell.frame.size, CGSize(width: tableViewController.tableView.frame.width, height: 200 + expect.additionalHeight + 0.5), accurancy: 1.0)
+                XCTAssertEqual(cell.contentView.frame.size, CGSize(width: tableViewController.tableView.frame.width, height: 200 + expect.additionalHeight), accurancy: 1.0)
                 let childViewController = tableViewController.children.first(where: { $0.view.superview == cell.contentView }) as! AutolayoutViewController
-                XCTAssertEqual(childViewController.view.frame.size, CGSize(width: min(tableViewController.tableView.frame.width, 200 + expect.additionalWidth), height: 200 + expect.additionalHeight))
+                XCTAssertEqual(childViewController.view.frame.size, CGSize(width: min(tableViewController.tableView.frame.width, 200 + expect.additionalWidth), height: 200 + expect.additionalHeight), accurancy: 1.0)
                 XCTAssertFalse(cell.hasAmbiguousLayout)
             }
         }

--- a/Tests/MewTests/TableViewCellTests.swift
+++ b/Tests/MewTests/TableViewCellTests.swift
@@ -23,7 +23,7 @@ class TableViewCellTests: XCTestCase {
         }
 
         INJECTABLE_VIEW: do {
-            let cell = View.dequeueAsTableViewCell(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: tableViewController) as! TableViewCell<Mew.ViewController<View, TableViewController>>
+            let cell = View.dequeueAsTableViewCell(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 39, parentViewController: tableViewController) as! TableViewCell<Mew.ViewController<View, Void>>
             XCTAssertEqual(cell.content.content.parameter, 39)
             XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
             XCTAssertEqual(cell.accessoryType, .none)
@@ -46,7 +46,7 @@ class TableViewCellTests: XCTestCase {
 
         INTERACTABLE_VIEW: do {
             var expected: Int?
-            let cell = View.dequeueAsTableViewCell(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: tableViewController) as! TableViewCell<Mew.ViewController<View, TableViewController>>
+            let cell = View.dequeueAsTableViewCell(from: tableViewController.tableView, for: IndexPath(row: 0, section: 0), input: 48, output: { expected = $0 }, parentViewController: tableViewController) as! TableViewCell<Mew.ViewController<View, Void>>
             XCTAssertEqual(cell.content.content.parameter, 48)
             XCTAssertTrue(cell.contentView.subviewTreeContains(with: cell.content.view))
             XCTAssertEqual(cell.accessoryType, .none)
@@ -68,7 +68,7 @@ class TableViewCellTests: XCTestCase {
         }
 
         INJECTABLE_VIEW: do {
-            let view = View.dequeueAsTableViewHeaderFooterView(from: tableViewController.tableView, input: 39, parentViewController: tableViewController) as! TableViewHeaderFooterView<Mew.ViewController<View, TableViewController>>
+            let view = View.dequeueAsTableViewHeaderFooterView(from: tableViewController.tableView, input: 39, parentViewController: tableViewController) as! TableViewHeaderFooterView<Mew.ViewController<View, Void>>
             XCTAssertEqual(view.content.content.parameter, 39)
             XCTAssertTrue(view.contentView.subviewTreeContains(with: view.content.view))
         }
@@ -85,7 +85,7 @@ class TableViewCellTests: XCTestCase {
 
         INTERACTABLE_VIEW: do {
             var expected: Int?
-            let view = View.dequeueAsTableViewHeaderFooterView(from: tableViewController.tableView, input: 48, output: { expected = $0 }, parentViewController: tableViewController) as! TableViewHeaderFooterView<Mew.ViewController<View, TableViewController>>
+            let view = View.dequeueAsTableViewHeaderFooterView(from: tableViewController.tableView, input: 48, output: { expected = $0 }, parentViewController: tableViewController) as! TableViewHeaderFooterView<Mew.ViewController<View, Void>>
             XCTAssertEqual(view.content.content.parameter, 48)
             XCTAssertTrue(view.contentView.subviewTreeContains(with: view.content.view))
             XCTAssertNil(expected)
@@ -112,7 +112,7 @@ class TableViewCellTests: XCTestCase {
                 tableViewController
             )
             XCTAssertEqual(
-                (tableViewController.tableView.headerView(forSection: 1) as? TableViewHeaderFooterView<Mew.ViewController<View, TableViewController>>)?.content.parent,
+                (tableViewController.tableView.headerView(forSection: 1) as? TableViewHeaderFooterView<Mew.ViewController<View, Void>>)?.content.parent,
                 tableViewController
             )
             parent.dismiss(animated: true, completion: {


### PR DESCRIPTION
closes #1 

`TableViewCell`, `TableViewHeaderFooterView`, `CollectionViewCell`, `CollectionReusableView` are available for both UIViewController and UIView.
Also, they will be internal class, so the way of registering/dequeueing is changed.

Registering UIViewController
```
ViewController.register(to: tableView)
ViewController.registerAsHeaderFooter(to: tableView)
ViewController.register(to: collectionView!)
ViewController.register(to: collectionView!, for: .header)
```

Registering UIView
```
View.register(to: tableView)
View.registerAsHeaderFooter(to: tableView)
View.register(to: collectionView!)
View.register(to: collectionView!, for: .header)
```

Dequeueing Cell with UIViewController
```
ViewController.dequeueCell(from: tableView, for: indexPath, input: input, parentViewController: self)
ViewController.dequeueHeaderFooterView(from: tableView, input: input, parentViewController: self)
ViewController.dequeueReusableCell(from: collectionView, for: indexPath, input: input, parentViewController: self)
ViewController.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: input, parentViewController: self)
```

Dequeueing Cell with UIView
```
View.dequeueCell(from: tableView, for: indexPath, input: input, parentViewController: self)
View.dequeueHeaderFooterView(from: tableView, input: input, parentViewController: self)
View.dequeueReusableCell(from: collectionView, for: indexPath, input: input, parentViewController: self)
View.dequeueReusableSupplementaryView(from: collectionView, of: kind, for: indexPath, input: input, parentViewController: self)
```